### PR TITLE
Use separate connection for writes where db_helper.copy_rows called...

### DIFF
--- a/subset.py
+++ b/subset.py
@@ -29,6 +29,7 @@ class Subset:
 
         self.__source_conn = source_dbc.get_db_connection(read_repeatable=True)
         self.__destination_conn = destination_dbc.get_db_connection()
+        self.__destination_write_conn = destination_dbc.get_db_connection()
 
         self.__all_tables = all_tables
 
@@ -174,7 +175,7 @@ class Subset:
             fk_columns = r['fk_columns']
 
             q='SELECT {} FROM {} WHERE {} NOT IN (SELECT {} FROM {})'.format(columns_joined(fk_columns), fully_qualified_table(mysql_db_name_hack(fk_table, self.__destination_conn)), columns_tupled(fk_columns), columns_joined(pk_columns), fully_qualified_table(mysql_db_name_hack(table, self.__destination_conn)))
-            self.__db_helper.copy_rows(self.__destination_conn, self.__destination_conn, q, temp_table)
+            self.__db_helper.copy_rows(self.__destination_conn, self.__destination_write_conn, q, temp_table)
 
         columns_query = columns_to_copy(table, relationships, self.__source_conn)
 


### PR DESCRIPTION
with the same source and destination connection.

With the MySQL database I am playing around, I get mysql.connector.errors.InternalError: Unread result found. The reason is, that db_helper.copy_rows writes while it is reading from the same connection. It is pretty tricky, because when you read the code of the method, you see copy_rows(source, destination), but once you call the method with the same connection, aka copy_rows(destination_conn, destination_conn) in subset.py

So I fixed the call to use separate connections for source and destination to avoid the annoying error.

Hope, it helps!

Ivan