### PR TITLE
Enable better handling of Large databases with limits and pre-filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Below we describe the use of all configuration parameters, but the best place to
 
 `keep_disconnected_tables`: If `true` tables that the subset target(s) don't reach, when following foreign keys, will be copied 100% over. If it's `false` then their schema will be copied but the table contents will be empty. Put more mathematically, the tables and foreign keys create a graph (where tables are nodes and foreign keys are directed edges) disconnected tables are the tables in components that don't contain any targets. This setting decides how to import those tables.
 
+`max_rows_per_table`: This is interpreted as a limit on all of the tables to be copied. Useful if you have some very large tables that you want a sampling from. For an unlimited dataset (recommended) set this parameter to `ALL`.
+
 `post_subset_sql`: An array of SQL commands that will be issued on the destination database after subsetting is complete. Useful to perform additional adhoc tasks after subsetting.
 
 # Running

--- a/config.json.example
+++ b/config.json.example
@@ -19,6 +19,7 @@
         "port": 5432
     },
     "keep_disconnected_tables": false,
+    "max_rows_per_table": ALL,
     "excluded_tables": [ ],
     "passthrough_tables": [ ],
     "dependency_breaks": [ ],

--- a/config.json.example_all
+++ b/config.json.example_all
@@ -34,6 +34,7 @@
             "condition": "condition_applied_to_any_table_with_this_column > 42"
         }
     ],
+    "max_rows_per_table": 100000,
     "excluded_tables": [
         "public.table_to_ignore", "public.spatial_ref_sys"
     ],

--- a/config_reader.py
+++ b/config_reader.py
@@ -56,6 +56,9 @@ def get_upstream_filters():
 def get_post_subset_sql():
     return _config["post_subset_sql"] if "post_subset_sql" in _config else []
 
+def get_max_rows_per_table():
+    return _config["max_rows_per_table"]
+
 def __convert_tonic_format(obj):
     if "fk_schema" in obj:
         return {


### PR DESCRIPTION
Thank you so much for open-sourcing this project! This is an incredibly useful tool!

I am trying to use this for a relatively simple database that has a lot of data in it. It was taking a long time to subset. Two relatively simple changes made this process a lot faster with relatively few trade offs: 

1) Pre-filtering: The data subsetter used to copy all of the data to a temporary table before applying any specified filters. This can obviously be sped up by only copying the data that will actually be used. In my case, I have some long time series data, that, at least for testing, I really only need the most recent few percent. By applying the filters before copying to the temporary table My copies got much faster. As an extra side benefit, if your target database has some corrupted data, you can filter it out without the subsetter needing to worry about it.

2) Limits: This is a bit of a hammer, but I think it is useful for a few reasons. First while you are developing/debugging your config file you can iterate faster. Also, It enables using the tool on databases that have one or two very large tables (logs for example).

Thanks again. Happy to discuss or support in any way I can.