### PR TITLE
add routines flag to initial mysql dump

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,47 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: |
+            derekyle/condenser:latest
+            ghcr.io/derekyle/condenser:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.9-slim-bullseye
+
+
+RUN apt-get update \
+  && apt-get install -y default-mysql-client unzip\
+  && rm -rf /var/lib/apt/lists/*
+
+RUN pip install toposort \
+  && pip install psycopg2-binary \
+  && pip install mysql-connector-python
+
+# COPY config.json /root/condenser/config.json
+
+COPY ./ /root/condenser/
+
+WORKDIR "/root/condenser"
+
+CMD python direct_subset.py -v

--- a/config.json.example_all
+++ b/config.json.example_all
@@ -1,11 +1,11 @@
 {
     "initial_targets": [
         {
-            "table": "public.target_table",
+            "table": "target_table",
             "percent": 10
         },
         {
-            "table": "public.users",
+            "table": "users",
             "where": "split_part(email, '@', 2) = 'hotmail.com'"
         }
     ],
@@ -26,7 +26,7 @@
     "keep_disconnected_tables": false,
     "upstream_filters": [
         {
-            "table": "public.an_upstream_table",
+            "table": "an_upstream_table",
             "condition": "timestamp > '01-01-2001'"
         },
         {
@@ -36,19 +36,22 @@
     ],
     "max_rows_per_table": 100000,
     "excluded_tables": [
-        "public.table_to_ignore", "public.spatial_ref_sys"
+        "table_to_ignore", "spatial_ref_sys"
     ],
     "passthrough_tables": [
-        "public.table_of_settings", "public.table_of_constants"
+        "table_of_settings", "table_of_constants"
     ],
     "dependency_breaks": [
-        {"fk_table": "schema2.table2", "target_table": "schema3.table3"}
+        {
+            "fk_table": "schema2.table2", 
+            "target_table": "schema3.table3"
+        }
     ],
     "fk_augmentation": [
         {
-            "fk_table": "public.fk_table",
+            "fk_table": "fk_table",
             "fk_columns": ["user_id"],
-            "target_table": "public.user",
+            "target_table": "user",
             "target_columns": ["id"]
         }
     ],

--- a/config_fixer.py
+++ b/config_fixer.py
@@ -1,0 +1,20 @@
+def config_fixer(target,db_name,is_tablename=False):
+
+  if isinstance(target,str) and is_tablename:
+    if (db_name + '.') not in target:
+      return db_name + '.' + target
+    return target
+    
+  elif isinstance(target,list):
+    return [config_fixer(list_target,db_name,is_tablename) for list_target in target]
+
+  elif isinstance(target,dict):
+
+    new_dict = {}
+    for mapkey in target:
+      new_dict[mapkey] = config_fixer(target[mapkey],db_name,("table" in mapkey))
+
+    return new_dict
+
+  else:
+    return target

--- a/config_reader.py
+++ b/config_reader.py
@@ -33,7 +33,7 @@ def get_initial_targets():
                 value = fix_tablename(value)
             new_target[key] = value
 
-    initial_targets.append(new_target)
+        initial_targets.append(new_target)
 
     return initial_targets
 

--- a/config_reader.py
+++ b/config_reader.py
@@ -17,8 +17,8 @@ def initialize(file_like = None):
         raise ValueError("desired_result is a key in the old config spec. Check the README.md and example-config.json for the latest configuration parameters.")
 
     db_name = os.environ.get('SOURCE_DB_NAME', _config['source_db_connection_info']['db_name'])
-    
-    _config = config_fixer(_config,db_name)
+
+    _config = config_fixer.config_fixer(_config,db_name)
 
 DependencyBreak = collections.namedtuple('DependencyBreak', ['fk_table', 'target_table'])
 

--- a/config_reader.py
+++ b/config_reader.py
@@ -1,4 +1,4 @@
-import json, sys, collections
+import json, sys, collections, os
 
 _config = None
 
@@ -36,9 +36,19 @@ def get_db_type():
     return _config['db_type']
 
 def get_source_db_connection_info():
+    _config['source_db_connection_info']['user_name'] = os.environ.get('SOURCE_USER_NAME', _config['source_db_connection_info']['user_name'])
+    _config['source_db_connection_info']['password'] = os.environ.get('SOURCE_PASSWORD', _config['source_db_connection_info']['password'])
+    _config['source_db_connection_info']['host'] = os.environ.get('SOURCE_HOST', _config['source_db_connection_info']['host'])
+    _config['source_db_connection_info']['db_name'] = os.environ.get('SOURCE_DB_NAME', _config['source_db_connection_info']['db_name'])
+    _config['source_db_connection_info']['port'] = os.environ.get('SOURCE_PORT', _config['source_db_connection_info']['port'])
     return _config['source_db_connection_info']
 
 def get_destination_db_connection_info():
+    _config['destination_db_connection_info']['user_name'] = os.environ.get('DESTINATION_USER_NAME', _config['destination_db_connection_info']['user_name'])
+    _config['destination_db_connection_info']['password'] = os.environ.get('DESTINATION_PASSWORD', _config['destination_db_connection_info']['password'])
+    _config['destination_db_connection_info']['host'] = os.environ.get('DESTINATION_HOST', _config['destination_db_connection_info']['host'])
+    _config['destination_db_connection_info']['db_name'] = os.environ.get('DESTINATION_DB_NAME', _config['destination_db_connection_info']['db_name'])
+    _config['destination_db_connection_info']['port'] = os.environ.get('DESTINATION_PORT', _config['destination_db_connection_info']['port'])
     return _config['destination_db_connection_info']
 
 def get_excluded_tables():

--- a/config_reader.py
+++ b/config_reader.py
@@ -16,7 +16,9 @@ def initialize(file_like = None):
     if "desired_result" in _config:
         raise ValueError("desired_result is a key in the old config spec. Check the README.md and example-config.json for the latest configuration parameters.")
 
-    _config = config_fixer(_config,os.environ.get('SOURCE_DB_NAME', _config['source_db_connection_info']['db_name']))
+    db_name = os.environ.get('SOURCE_DB_NAME', _config['source_db_connection_info']['db_name'])
+    
+    _config = config_fixer(_config,db_name)
 
 DependencyBreak = collections.namedtuple('DependencyBreak', ['fk_table', 'target_table'])
 

--- a/config_reader.py
+++ b/config_reader.py
@@ -8,7 +8,7 @@ def initialize(file_like = None):
         print('WARNING: Attempted to initialize configuration twice.', file=sys.stderr)
 
     if not file_like:
-        with open('config.json', 'r') as fp:
+        with open(os.environ.get('CONFIG_PATH', 'config.json'), 'r') as fp:
             _config = json.load(fp)
     else:
         _config = json.load(file_like)

--- a/config_reader.py
+++ b/config_reader.py
@@ -12,11 +12,26 @@ def initialize(file_like = None):
             _config = json.load(fp)
     else:
         _config = json.load(file_like)
+        _config = add_db_name_prefixes(_config)
 
     if "desired_result" in _config:
         raise ValueError("desired_result is a key in the old config spec. Check the README.md and example-config.json for the latest configuration parameters.")
 
 DependencyBreak = collections.namedtuple('DependencyBreak', ['fk_table', 'target_table'])
+
+def add_db_name_prefixes(new_config):
+    source_db_name = get_source_db_connection_info()['db_name'];
+
+    for mkey, mvalue in new_config:
+        for key, value in mvalue:
+            if key == "table":
+                if (source_db_name + '.') not in value:
+                    value = source_db_name + '.' + value
+
+            new_config[mkey][key] = value
+
+    return new_config
+
 def get_dependency_breaks():
     return set([DependencyBreak(b['fk_table'], b['target_table']) for b in _config['dependency_breaks']])
 

--- a/config_reader.py
+++ b/config_reader.py
@@ -55,7 +55,7 @@ def get_destination_db_connection_info():
     return _config['destination_db_connection_info']
 
 def get_excluded_tables():
-    return list(_config['excluded_tables']
+    return list(_config['excluded_tables'])
 
 def get_passthrough_tables():
     return  list(_config['passthrough_tables'])

--- a/config_reader.py
+++ b/config_reader.py
@@ -12,25 +12,11 @@ def initialize(file_like = None):
             _config = json.load(fp)
     else:
         _config = json.load(file_like)
-        _config = add_db_name_prefixes(_config)
 
     if "desired_result" in _config:
         raise ValueError("desired_result is a key in the old config spec. Check the README.md and example-config.json for the latest configuration parameters.")
 
 DependencyBreak = collections.namedtuple('DependencyBreak', ['fk_table', 'target_table'])
-
-def add_db_name_prefixes(new_config):
-    source_db_name = get_source_db_connection_info()['db_name'];
-
-    for mkey, mvalue in new_config:
-        for key, value in mvalue:
-            if key == "table":
-                if (source_db_name + '.') not in value:
-                    value = source_db_name + '.' + value
-
-            new_config[mkey][key] = value
-
-    return new_config
 
 def get_dependency_breaks():
     return set([DependencyBreak(b['fk_table'], b['target_table']) for b in _config['dependency_breaks']])
@@ -39,10 +25,20 @@ def get_preserve_fk_opportunistically():
     return set([DependencyBreak(b['fk_table'], b['target_table']) for b in _config['dependency_breaks'] if 'perserve_fk_opportunistically' in b and b['perserve_fk_opportunistically']])
 
 def get_initial_targets():
-    return _config['initial_targets']
+    initial_targets = []
+    for target in _config['initial_targets']:
+        new_target = {}
+        for key, value in target:
+            if key == 'table':
+                value = fix_tablename(value)
+            new_target.append({key:value})
+
+    initial_targets.append(new_target)
+
+    return initial_targets
 
 def get_initial_target_tables():
-    return [target["table"] for target in _config['initial_targets']]
+    return [fix_tablename(target["table"]) for target in _config['initial_targets']]
 
 def keep_disconnected_tables():
     return 'keep_disconnected_tables' in _config and bool(_config['keep_disconnected_tables'])
@@ -67,10 +63,10 @@ def get_destination_db_connection_info():
     return _config['destination_db_connection_info']
 
 def get_excluded_tables():
-    return list(_config['excluded_tables'])
+    return [fix_tablename(target) for target in list(_config['excluded_tables'])]
 
 def get_passthrough_tables():
-    return list(_config['passthrough_tables'])
+    return  [fix_tablename(target) for target in list(_config['passthrough_tables'])]
 
 def get_fk_augmentation():
     return list(map(__convert_tonic_format, _config['fk_augmentation']))
@@ -100,3 +96,8 @@ def __convert_tonic_format(obj):
 
 def verbose_logging():
     return '-v' in sys.argv
+
+def fix_tablename(table):
+    if (get_source_db_connection_info()['db_name'] + '.') not in table:
+        return get_source_db_connection_info()['db_name'] + '.' + table
+    return table

--- a/config_reader.py
+++ b/config_reader.py
@@ -31,7 +31,7 @@ def get_initial_targets():
         for key, value in target:
             if key == 'table':
                 value = fix_tablename(value)
-            new_target.append({key:value})
+            new_target[key] = value
 
     initial_targets.append(new_target)
 

--- a/config_reader.py
+++ b/config_reader.py
@@ -28,10 +28,11 @@ def get_initial_targets():
     initial_targets = []
     for target in _config['initial_targets']:
         new_target = {}
-        for key, value in target:
+        for key in target:
             if key == 'table':
-                value = fix_tablename(value)
-            new_target[key] = value
+                target[key] = fix_tablename(target[key])
+
+            new_target[key] = target[key]
 
         initial_targets.append(new_target)
 

--- a/mysql_database_creator.py
+++ b/mysql_database_creator.py
@@ -14,7 +14,7 @@ class MySqlDatabaseCreator:
             os.chdir(mysql_bin_path)
 
         ca = connection_args(self.__source_connect)
-        args = ['mysqldump', '-d'] + ca + [self.__source_connect.db_name]
+        args = ['mysqldump', '--no-data', '--routines'] + ca + [self.__source_connect.db_name]
         result = subprocess.run(args, stdout = subprocess.PIPE, stderr = subprocess.PIPE)
         if result.returncode != 0:
             raise Exception('Capturing schema failed. Details:\n{}'.format(result.stderr))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 toposort
 psycopg2-binary
 mysql-connector-python
+toolz


### PR DESCRIPTION
Routines like functions and procedures don't dump by default when using the mysqldump command. This should dump all the routines data as well as the table schema. Without this, the synchronization fails near the end if you have any functions or procedures in your source database and of course you also don't sync over those routines.

Small note, I also replaced the cryptic -d flag with the more descriptive --no-data flag for clarity.