### PR TITLE
fix: sql keyword in column names

### DIFF
--- a/psql_database_helper.py
+++ b/psql_database_helper.py
@@ -33,7 +33,7 @@ def copy_rows(source, destination, query, destination_table):
             return '%s'
 
     template = '(' + ','.join([template_piece(dt[1]) for dt in non_generated_columns]) + ')'
-    columns = '(' + ','.join([dt[0] for dt in non_generated_columns]) + ')'
+    columns = '("' + '","'.join([dt[0] for dt in non_generated_columns]) + '")'
 
     cursor_name='table_cursor_'+str(uuid.uuid4()).replace('-','')
     cursor = source.cursor(name=cursor_name)


### PR DESCRIPTION
This PR prevent crash when a column name is a PostgreSQL keyword https://www.postgresql.org/docs/current/sql-keywords-appendix.html